### PR TITLE
Object orientated flip.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ php:
   - 5.6
   - 7.0
   - hhvm
-  - hhvm-nightly
 
 sudo: false
 

--- a/lib/flip.php
+++ b/lib/flip.php
@@ -14,9 +14,9 @@ class ┻━┻ extends Exception
     {
         return "┬─┬";
     }
-    +    
-+    public static function ノ（°□°ノ）()
-+    {
-+        throw new static();
-+    }
+
+    public static function ノ（°□°ノ）()
+    {
+        throw new static();
+    }
 }

--- a/lib/flip.php
+++ b/lib/flip.php
@@ -14,4 +14,9 @@ class ┻━┻ extends Exception
     {
         return "┬─┬";
     }
+    +    
++    public static function ノ（°□°ノ）()
++    {
++        throw new static();
++    }
 }

--- a/tests/Test.php
+++ b/tests/Test.php
@@ -10,4 +10,13 @@ class Test extends PHPUnit_Framework_TestCase
     {
         （╯°□°）╯︵┻━┻();
     }
+
+    /**
+     * @expectedException ┻━┻
+     * @expectedExceptionMessage Please respect tables! ┬─┬ノ(ಠ_ಠノ)
+     */
+    public function testObjectOrientatedExceptionIsThrown()
+    {
+        ┻━┻::ノ（°□°ノ）();
+    }
 }


### PR DESCRIPTION
Though perhaps it defeats the very purposed of having a `（╯°□°）╯︵┻━┻()` library.

Usage:

``` php
┻━┻::ノ（°□°ノ）();
```

As an alternative, this could also be an option, though I haven't implemented it here:

``` php
class （╯°□°）╯
{
    public static function ︵┻━┻()
    {
        throw new ┻━┻();
    }
}
```

Usage:

``` php
（╯°□°）╯::︵┻━┻();
```
